### PR TITLE
add pharo8 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ smalltalk:
   - Pharo-7.0
   - Pharo-6.1
   - Pharo64-7.0
+  - Pharo32-8.0
+  - Pharo64-8.0


### PR DESCRIPTION
add pharo8 (32 and 64bits) to travis.yml