### PR TITLE
 Magritte Support - Make More Command-Like

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVImporter.class.st
@@ -1,27 +1,28 @@
 Class {
-	#name : #MACSVImporter,
-	#superclass : #Object,
+	#name : 'MACSVImporter',
+	#superclass : 'Object',
 	#instVars : [
 		'reader',
 		'readerClass',
 		'recordClass',
-		'stream'
+		'source'
 	],
-	#category : #'Neo-CSV-Magritte-Visitors'
+	#category : 'Neo-CSV-Magritte-Visitors'
 }
 
-{ #category : #accessing }
-MACSVImporter >> importFile: file [
-	
-	^ file readStreamDo: [ :str | self importStream: str ]
+{ #category : 'accessing' }
+MACSVImporter >> execute [
+	^ self source isStream
+		ifTrue: [ self importStream: self source ]
+		ifFalse: [ self source readStreamDo: [ :str | self importStream: str ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'private' }
 MACSVImporter >> importStream: aStream [
 	
 	| fields header |
-	self stream: aStream.
-	header := self reader readHeader.
+	self reader on: aStream.
+	header := self readHeader.
 	self reader recordClass: self recordClass.
 	fields := self recordClass new magritteDescription children.
 	header do: [ :h | 
@@ -32,37 +33,45 @@ MACSVImporter >> importStream: aStream [
 	^ self reader upToEnd "or do more processing e.g. `select: [ :record | record lastName isNotNil ]`"
 ]
 
-{ #category : #accessing }
-MACSVImporter >> reader [
-	^ reader ifNil: [ reader := self readerClass on: self stream ]
+{ #category : 'private' }
+MACSVImporter >> readHeader [
+	"For exotic headers (i.e. not a single line with field names), override this. For example, you may for example want to skip irrevelant/blank lines."
+	^ self reader readHeader
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
+MACSVImporter >> reader [
+	^ reader ifNil: [ reader := self readerClass new ]
+]
+
+{ #category : 'accessing' }
 MACSVImporter >> readerClass [
 	^ readerClass ifNil: [ NeoCSVReader ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVImporter >> readerClass: aClass [
 	readerClass := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVImporter >> recordClass [
 	^ recordClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVImporter >> recordClass: aClass [
 	recordClass := aClass
 ]
 
-{ #category : #accessing }
-MACSVImporter >> stream [
-	^ stream
+{ #category : 'accessing' }
+MACSVImporter >> source [
+
+	^ source
 ]
 
-{ #category : #accessing }
-MACSVImporter >> stream: aStream [ 
-	stream := aStream
+{ #category : 'accessing' }
+MACSVImporter >> source: aFileOrStream [
+
+	source := aFileOrStream
 ]

--- a/repository/Neo-CSV-Magritte/MACSVImporterTests.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVImporterTests.class.st
@@ -1,53 +1,55 @@
 Class {
-	#name : #MACSVImporterTests,
-	#superclass : #TestCase,
+	#name : 'MACSVImporterTests',
+	#superclass : 'TestCase',
 	#instVars : [
 		'input',
 		'importer',
 		'objects'
 	],
-	#category : #'Neo-CSV-Magritte-Tests'
+	#category : 'Neo-CSV-Magritte-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 MACSVImporterTests >> readInput: aString [ 
-	objects :=  importer importStream: aString readStream
+	objects :=  importer 
+		source: aString readStream;
+		execute
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MACSVImporterTests >> setUp [
 	importer :=  MACSVTestPerson maCSVImporter: MACSVImporter.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MACSVImporterTests >> testCustomConversion [
 	self readInput: 'Phone Number,Ignored Field
 1-203-555-0100,something'.
 	self assert: objects first phoneNumber equals: 12035550100.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MACSVImporterTests >> testDateDefaultConversion [
 	self readInput: 'DOB,Ignored Field
 2/28/2020,something'.
 	self assert: objects first birthdate equals: '2/28/2020' asDate.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MACSVImporterTests >> testEmptyField [
 	self readInput: 'Phone Number,Ignored Field
 ,something'.
 	self assert: objects first phoneNumber equals: nil.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MACSVImporterTests >> testStringDefaultConversion [
 	self readInput: 'Name,Ignored Field
 Alan Kay,something'.
 	self assert: objects first name equals: 'Alan Kay'.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 MACSVImporterTests >> testTrailingLeadingSpaceIgnored [
 	self readInput: 'Name,Ignored Field
  Alan Kay   ,something'.

--- a/repository/Neo-CSV-Magritte/MACSVTestPerson.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTestPerson.class.st
@@ -1,26 +1,26 @@
 Class {
-	#name : #MACSVTestPerson,
-	#superclass : #Object,
+	#name : 'MACSVTestPerson',
+	#superclass : 'Object',
 	#instVars : [
 		'customReadField',
 		'phoneNumber',
 		'birthdate',
 		'name'
 	],
-	#category : #'Neo-CSV-Magritte-Tests'
+	#category : 'Neo-CSV-Magritte-Tests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> birthdate [
 	^ self maLazyInstVarUsing: self birthdateDescription
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> birthdate: aDate [
 	birthdate := aDate
 ]
 
-{ #category : #'magritte-accessing' }
+{ #category : 'magritte-accessing' }
 MACSVTestPerson >> birthdateDescription [
 	<magritteDescription>
 	^ MADateDescription new
@@ -29,17 +29,17 @@ MACSVTestPerson >> birthdateDescription [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> name [
 	^ self maLazyInstVarUsing: self nameDescription
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> name: aString [
 	name := aString
 ]
 
-{ #category : #'magritte-accessing' }
+{ #category : 'magritte-accessing' }
 MACSVTestPerson >> nameDescription [
 	<magritteDescription>
 	^ MAStringDescription new
@@ -48,17 +48,17 @@ MACSVTestPerson >> nameDescription [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> phoneNumber [
 	^ self maLazyInstVarUsing: self phoneNumberDescription
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTestPerson >> phoneNumber: aNumber [
 	phoneNumber := aNumber
 ]
 
-{ #category : #'magritte-accessing' }
+{ #category : 'magritte-accessing' }
 MACSVTestPerson >> phoneNumberDescription [
 	<magritteDescription>
 	^ MANumberDescription new

--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -1,23 +1,23 @@
 Class {
-	#name : #MACSVTwoStageImporter,
-	#superclass : #MACSVImporter,
-	#category : #'Neo-CSV-Magritte-Neo-CSV-Magritte'
+	#name : 'MACSVTwoStageImporter',
+	#superclass : 'MACSVImporter',
+	#category : 'Neo-CSV-Magritte-Neo-CSV-Magritte'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTwoStageImporter >> convertToDomainObjects: aCollectionOfDictionaries [
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTwoStageImporter >> importStream: aStream [
 	| rows |
-	self stream: aStream.
+	self reader on: aStream.
 	rows := self readInput.
 	^ self convertToDomainObjects: rows
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionary [
 	"We needed an instance-side version because some objects may need configuration during instance creation"
 	anObject magritteDescription do: [ :desc | 
@@ -33,7 +33,7 @@ MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionar
 	^ anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MACSVTwoStageImporter >> readInput [
 	^ self reader
 		emptyFieldValue: #passNil;

--- a/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
+++ b/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
@@ -1,30 +1,30 @@
-Extension { #name : #MAElementDescription }
+Extension { #name : 'MAElementDescription' }
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 MAElementDescription >> csvFieldName [
 	^ self propertyAt: #csvFieldName ifAbsent: [ nil ]
 ]
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 MAElementDescription >> csvFieldName: aString [
 	^ self propertyAt: #csvFieldName put: aString
 ]
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 MAElementDescription >> csvReader [
 	| default |
 	default := [ :trimmed | self fromString: trimmed ].
 	^ self propertyAt: #csvReader ifAbsent: [ default ]
 ]
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 MAElementDescription >> csvReader: aBlock [
 	"
 	aBlock - should take the input string as its argument and return a value appropriate to the field e.g. aDate for MADateDescription."
 	^ self propertyAt: #csvReader put: aBlock
 ]
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 MAElementDescription >> fromCSV: aStringOrNil [
 	| value |
 	(aStringOrNil isNil or: [ aStringOrNil isEmpty ]) ifTrue: [ ^ nil ].

--- a/repository/Neo-CSV-Magritte/ManifestNeoCSVMagritte.class.st
+++ b/repository/Neo-CSV-Magritte/ManifestNeoCSVMagritte.class.st
@@ -18,17 +18,19 @@ MyPerson>>#descriptionPhone
 
 ### 2. Read a CSV File
 - The main entry point is `MyDomainClass class>>#maCSVImporter: aVisitorClass`.
-- The header must be a single line with field names. You may manually skip leading irrevelant/blank lines.
+- The header must be a single line with field names. See the {{gtMethod:MACSVImporter>>#readHeader}} hook, provided to e.g. manually skip leading irrevelant/blank lines.
 
 Example:
 ```smalltalk
 file :=  self myFolder / 'my_contacts.csv'.
 importer :=  MyPerson maCSVImporter: MACSVImporter.
-collectionOfMyDomainObjects :=  importer importFile: file
+collectionOfMyDomainObjects :=  importer 
+	source: file;
+	execute.
 ```
 "
 Class {
-	#name : #ManifestNeoCSVMagritte,
-	#superclass : #PackageManifest,
-	#category : #'Neo-CSV-Magritte-Manifest'
+	#name : 'ManifestNeoCSVMagritte',
+	#superclass : 'PackageManifest',
+	#category : 'Neo-CSV-Magritte-Manifest'
 }

--- a/repository/Neo-CSV-Magritte/NeoCSVReader.extension.st
+++ b/repository/Neo-CSV-Magritte/NeoCSVReader.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #NeoCSVReader }
+Extension { #name : 'NeoCSVReader' }
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 NeoCSVReader >> addFieldDescribedByMagritte: aDescription [ 
 
 	self 

--- a/repository/Neo-CSV-Magritte/Object.extension.st
+++ b/repository/Neo-CSV-Magritte/Object.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 Object class >> maCSVImporter: importerClass [
 	^ importerClass new
 		recordClass: self;
 		yourself.
 ]
 
-{ #category : #'*Neo-CSV-Magritte' }
+{ #category : '*Neo-CSV-Magritte' }
 Object class >> maGenerateFieldsFromCSVHeaders: aString [
 	"Given a class-side `#headers` message returning a tab-separated string (e.g. pasted from MS Excel), generate a field (i.e. constructor and accessors) for each token"
 	

--- a/repository/Neo-CSV-Magritte/package.st
+++ b/repository/Neo-CSV-Magritte/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Neo-CSV-Magritte' }
+Package { #name : 'Neo-CSV-Magritte' }


### PR DESCRIPTION
    
    - Accept a file or stream via same API
    - Add `#execute` message to defer running, make usage more flexible
    - Update documentation (e.g. package manifest)
    - Update tests, all passing