### PR TITLE
[Enh]: Magritte Importer - Hook to Customize Field Name Property

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVImporter.class.st
@@ -7,7 +7,7 @@ Class {
 		'recordClass',
 		'source'
 	],
-	#category : 'Neo-CSV-Magritte-Visitors'
+	#category : #'Neo-CSV-Magritte-Visitors'
 }
 
 { #category : #accessing }
@@ -15,6 +15,13 @@ MACSVImporter >> execute [
 	^ self source isStream
 		ifTrue: [ self importStream: self source ]
 		ifFalse: [ self source readStreamDo: [ :str | self importStream: str ] ]
+]
+
+{ #category : #accessing }
+MACSVImporter >> fieldNamePropertyKey [
+	"The property where the element description stores the field name; override to customize"
+
+	^ #csvFieldName
 ]
 
 { #category : #private }
@@ -27,7 +34,11 @@ MACSVImporter >> importStream: aStream [
 	fields := self recordClass new magritteDescription children.
 	header do: [ :h | 
 		fields
-			detect: [ :f | f csvFieldName = h asString trimmed ]
+			detect: [ :f | 
+					f 
+						propertyAt: self fieldNamePropertyKey 
+						ifPresent: [ :fieldName | fieldName = h asString trimmed ]
+						ifAbsent: [ false ] ]
 			ifFound: [ :e | self reader addFieldDescribedByMagritte: e ]
 			ifNone: [ self reader addIgnoredField ] ].
 	^ self reader upToEnd "or do more processing e.g. `select: [ :record | record lastName isNotNil ]`"

--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -22,7 +22,7 @@ MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionar
 	"We needed an instance-side version because some objects may need configuration during instance creation"
 	anObject magritteDescription do: [ :desc | 
 		desc
-			propertyAt: #csvFieldName
+			propertyAt: self fieldNamePropertyKey
 			ifPresent: [ :fieldName | 
 				| stringValue value |
 				stringValue := aDictionary at: fieldName.


### PR DESCRIPTION
`#csvFieldName` was hardcoded, but we may need different field names for different purposes e.g. contacts which can be exported from either google or outlook