### PR TITLE
[Enh]: Magritte Readers - More Flexible Customization

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVMappedPragmaBuilder.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVMappedPragmaBuilder.class.st
@@ -1,0 +1,96 @@
+"
+I provide a way to extend Magritte element descriptions for CSV reading without modifying the containing domain class. I help avoid bloating domain classes with extensions for each supported CSV source. For example, for contacts, Google has its field names, Outlook has others…  By using me, you will not have to extend existing element descriptions via Magritte's pragma (the one that takes the description selector as an argument).
+
+To configure me, you should:
+- set the `#fieldNamePropertyKey` that your reader expects to map descriptions to CSV fields
+- as needed, specify the `#fieldReaderPropertyKey` that your reader uses to convert the CSV field string to a domain object; otherwise the default reader will be used
+
+The two primary ways to map fields to descriptions are:
+-  `aBuilder map: fieldName fieldTo: descriptionSelector`
+-  `aBuilder map: fieldName fieldTo: descriptionSelector using: reader`
+"
+Class {
+	#name : #MACSVMappedPragmaBuilder,
+	#superclass : #MAPragmaBuilder,
+	#instVars : [
+		'map',
+		'fieldNamePropertyKey',
+		'fieldReaderPropertyKey'
+	],
+	#category : #'Neo-CSV-Magritte-Support'
+}
+
+{ #category : #private }
+MACSVMappedPragmaBuilder >> description: description extendedBy: descriptionExtensions for: descriptionSelector of: anObject [
+	| result |
+	result := super
+		description: description
+		extendedBy: descriptionExtensions
+		for: descriptionSelector
+		of: anObject.
+
+	self ensureFieldPropertiesForDescription: result from: descriptionSelector.
+
+	^ result
+]
+
+{ #category : #private }
+MACSVMappedPragmaBuilder >> ensureFieldPropertiesForDescription: description from: descriptionSelector [ 
+
+	self map
+		at: descriptionSelector
+		ifPresent: [ :anArray | 
+			description 
+				propertyAt: self fieldNamePropertyKey
+				put: anArray first.
+			
+			anArray second ifNil: [ ^ self ].
+			description 
+				propertyAt: self fieldReaderPropertyKey
+				put: [ :trimmed | 
+					anArray second 
+						cull: trimmed 
+						cull: description ] ].
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> fieldNamePropertyKey [
+	^ fieldNamePropertyKey
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> fieldNamePropertyKey: anObject [
+	fieldNamePropertyKey := anObject
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> fieldReaderPropertyKey [
+	^ fieldReaderPropertyKey
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> fieldReaderPropertyKey: anObject [
+	fieldReaderPropertyKey := anObject
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> map [
+	^ map ifNil: [ map := Dictionary new ]
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> map: anObject [
+	map := anObject
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> map: fieldName fieldTo: descriptionSelector [
+
+	 self map: fieldName fieldTo: descriptionSelector using: nil
+]
+
+{ #category : #accessing }
+MACSVMappedPragmaBuilder >> map: fieldName fieldTo: descriptionSelector using: reader [
+
+	 self map at: descriptionSelector put: { fieldName. reader }
+]

--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MACSVTwoStageImporter,
 	#superclass : #MACSVImporter,
-	#category : #'Neo-CSV-Magritte-Neo-CSV-Magritte'
+	#category : #'Neo-CSV-Magritte-Visitors'
 }
 
 { #category : #accessing }

--- a/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
+++ b/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
@@ -12,9 +12,8 @@ MAElementDescription >> csvFieldName: aString [
 
 { #category : #'*Neo-CSV-Magritte' }
 MAElementDescription >> csvReader [
-	| default |
-	default := [ :trimmed | self fromString: trimmed ].
-	^ self propertyAt: #csvReader ifAbsent: [ default ]
+
+	^ self propertyAt: #csvReader ifAbsent: [ self defaultCsvReader ]
 ]
 
 { #category : #'*Neo-CSV-Magritte' }
@@ -22,6 +21,12 @@ MAElementDescription >> csvReader: aBlock [
 	"
 	aBlock - should take the input string as its argument and return a value appropriate to the field e.g. aDate for MADateDescription."
 	^ self propertyAt: #csvReader put: aBlock
+]
+
+{ #category : #'*Neo-CSV-Magritte' }
+MAElementDescription >> defaultCsvReader [
+
+	^ [ :trimmed | self fromString: trimmed ].
 ]
 
 { #category : #'*Neo-CSV-Magritte' }


### PR DESCRIPTION
- Pragma Builder that maps CSV field names and reader blocks to element descriptions without overriding or extending methods
- Extract the default element description CSV reader so it can be used elsewhere