### PR TITLE
[Magritte]: Make Two-Stage Importer More Flexible

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVImporter.class.st
@@ -24,6 +24,13 @@ MACSVImporter >> fieldNamePropertyKey [
 	^ #csvFieldName
 ]
 
+{ #category : #accessing }
+MACSVImporter >> fieldReaderPropertyKey [
+	"The property where the element description stores the field reader. Override to customize. See `MAElementDescription>>#csvReader:` method comment for more info"
+
+	^ #csvReader
+]
+
 { #category : #private }
 MACSVImporter >> importStream: aStream [
 	
@@ -39,7 +46,9 @@ MACSVImporter >> importStream: aStream [
 						propertyAt: self fieldNamePropertyKey 
 						ifPresent: [ :fieldName | fieldName = h asString trimmed ]
 						ifAbsent: [ false ] ]
-			ifFound: [ :e | self reader addFieldDescribedByMagritte: e ]
+			ifFound: [ :e | 
+				self flag: 'need a way to customize the reader here'.
+				self reader addFieldDescribedByMagritte: e ]
 			ifNone: [ self reader addIgnoredField ] ].
 	^ self reader upToEnd "or do more processing e.g. `select: [ :record | record lastName isNotNil ]`"
 ]

--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -1,12 +1,33 @@
 Class {
 	#name : #MACSVTwoStageImporter,
 	#superclass : #MACSVImporter,
+	#instVars : [
+		'selectBlock',
+		'preprocessor'
+	],
 	#category : #'Neo-CSV-Magritte-Visitors'
 }
 
 { #category : #accessing }
 MACSVTwoStageImporter >> convertToDomainObjects: aCollectionOfDictionaries [
-	self subclassResponsibility
+	^ aCollectionOfDictionaries
+		inject: OrderedCollection new 
+		into: [ :col :rowDict | 
+			| result |
+			self preprocessor value: rowDict.
+			(self selectBlock value: rowDict)
+				ifTrue: [ 
+					result := self domainObjectFromDictionary: rowDict.
+					col add: result ].
+			col ]
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> domainObjectFromDictionary: aDictionary [
+
+	^ self 
+		initializeDomainObject: self recordClass new 
+		fromRecord: aDictionary
 ]
 
 { #category : #accessing }
@@ -20,17 +41,64 @@ MACSVTwoStageImporter >> importStream: aStream [
 { #category : #accessing }
 MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionary [
 	"We needed an instance-side version because some objects may need configuration during instance creation"
-	anObject magritteDescription do: [ :desc | 
+	
+	^ self 
+		initializeDomainObject: anObject 
+		fromRecord: aDictionary 
+		mapping: [ :builder | ]
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionary mapping: aBlock [
+	
+	^ self
+		initializeDomainObject: anObject
+		fromRecord: aDictionary
+		mapping: aBlock
+		descriptionDo: #yourself
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionary mapping: mapBlock descriptionDo: descriptionBlock [
+	"
+	anObject - domain objec to be initialized
+	aDictionary - keys are CSV column names
+	mapBlock - use to modify existing descriptions; argument will be an MACSVMappingPragmaBuilder to configure
+	descriptionBlock - argument is the container description for anObject, for further configuration e.g. adding an element description"
+	
+	| contDesc builder |
+	builder := MACSVMappedPragmaBuilder new
+		fieldNamePropertyKey: self fieldNamePropertyKey;
+		fieldReaderPropertyKey: self fieldReaderPropertyKey;
+		yourself.
+	mapBlock value: builder.
+		
+	contDesc := builder for: anObject.
+	descriptionBlock value: contDesc.
+	contDesc do: [ :desc | 
 		desc
 			propertyAt: self fieldNamePropertyKey
 			ifPresent: [ :fieldName | 
-				| stringValue value |
+				| stringValue value fieldReader |
 				stringValue := aDictionary at: fieldName.
 				self flag: 'This next part looks very memento-like'.
 				stringValue ifNotNil: [ 
-					value := desc csvReader value: stringValue.
+					fieldReader := desc 
+						propertyAt: self fieldReaderPropertyKey
+						ifAbsent: [ desc csvReader ].
+					value := fieldReader value: stringValue.
 					desc write: value to: anObject ] ] ].
 	^ anObject
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> preprocessor [
+	^ preprocessor ifNil: [ #yourself ]
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> preprocessor: anObject [
+	preprocessor := anObject
 ]
 
 { #category : #accessing }
@@ -39,4 +107,14 @@ MACSVTwoStageImporter >> readInput [
 		emptyFieldValue: #passNil;
 		namedColumnsConfiguration;
 		upToEnd.
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> selectBlock [
+	^ selectBlock ifNil: [ #isNotNil ]
+]
+
+{ #category : #accessing }
+MACSVTwoStageImporter >> selectBlock: anObject [
+	selectBlock := anObject
 ]


### PR DESCRIPTION
- map columns to element descriptions on the fly, without polluting domain classes
- add custom descriptions easily
- preprocess input
- select certain objects to return
- split object collection and individual object handling
- custom reader property keys