### PR TITLE
[Feature]: Magritte Writer

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVField.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVField.class.st
@@ -1,0 +1,82 @@
+Class {
+	#name : #MACSVField,
+	#superclass : #Object,
+	#instVars : [
+		'descriptionSource',
+		'name',
+		'encoder',
+		'decoder'
+	],
+	#category : #'Neo-CSV-Magritte'
+}
+
+{ #category : #accessing }
+MACSVField >> configureDescriptionFor: aWriter [
+
+	| description |
+	self descriptionSource isSymbol ifTrue: [
+		description := aWriter subjectDescription detect: [ :fieldDesc | 
+			fieldDesc definingContext methodSelector = self descriptionSource ] ].
+		
+	self descriptionSource isBlock ifTrue: [
+		description := self descriptionSource value.
+		aWriter subjectDescription add: description ].
+		
+	description 
+		propertyAt: aWriter fieldNamePropertyKey
+		put: self name.
+			
+	self encoder ifNotNil: [ :anEncoder |
+		description 
+			propertyAt: aWriter fieldWriterPropertyKey
+			put: anEncoder ].
+			
+	self decoder ifNotNil: [ :aDecoder |
+		description 
+			propertyAt: aWriter fieldWriterPropertyKey
+			put: aDecoder ].
+			
+	^ description
+]
+
+{ #category : #accessing }
+MACSVField >> decoder [
+	^ decoder
+]
+
+{ #category : #accessing }
+MACSVField >> decoder: anObject [
+	decoder := anObject
+]
+
+{ #category : #accessing }
+MACSVField >> descriptionSource [
+	^ descriptionSource
+]
+
+{ #category : #accessing }
+MACSVField >> descriptionSource: anObject [
+	"anObject - either a block returning a description, or the defining selector of a description already defined by the domain objects being written"
+	
+	descriptionSource := anObject
+]
+
+{ #category : #accessing }
+MACSVField >> encoder [
+	^ encoder
+]
+
+{ #category : #accessing }
+MACSVField >> encoder: anObject [
+	encoder := anObject
+]
+
+{ #category : #accessing }
+MACSVField >> name [
+	^ name
+]
+
+{ #category : #accessing }
+MACSVField >> name: anObject [
+	name := anObject
+]

--- a/repository/Neo-CSV-Magritte/MACSVTestPerson.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTestPerson.class.st
@@ -2,13 +2,34 @@ Class {
 	#name : #MACSVTestPerson,
 	#superclass : #Object,
 	#instVars : [
-		'customReadField',
 		'phoneNumber',
 		'birthdate',
-		'name'
+		'name',
+		'birthplace',
+		'wikipediaUrl'
 	],
 	#category : #'Neo-CSV-Magritte-Tests'
 }
+
+{ #category : #accessing }
+MACSVTestPerson class >> exampleAlanKay [
+
+	^ self new
+		name: 'Alan Kay';
+		birthdate: '5/17/1940' asDate;
+		birthplace: 'Springfield, Massachusetts, U.S.';
+		wikipediaUrl: 'https://en.wikipedia.org/wiki/Alan_Kay' asUrl
+		yourself
+]
+
+{ #category : #'magritte-accessing' }
+MACSVTestPerson >> addressDescription [
+	<magritteDescription>
+	^ MAStringDescription new
+		accessor: #address;
+		priority: 40;
+		yourself
+]
 
 { #category : #accessing }
 MACSVTestPerson >> birthdate [
@@ -26,6 +47,26 @@ MACSVTestPerson >> birthdateDescription [
 	^ MADateDescription new
 		accessor: #birthdate;
 		csvFieldName: 'DOB';
+		priority: 30;
+		yourself
+]
+
+{ #category : #accessing }
+MACSVTestPerson >> birthplace [
+	^ birthplace
+]
+
+{ #category : #accessing }
+MACSVTestPerson >> birthplace: anObject [
+	birthplace := anObject
+]
+
+{ #category : #'magritte-accessing' }
+MACSVTestPerson >> birthplaceDescription [
+	<magritteDescription>
+	^ MAStringDescription new
+		accessor: #birthplace;
+		priority: 40;
 		yourself
 ]
 
@@ -45,6 +86,7 @@ MACSVTestPerson >> nameDescription [
 	^ MAStringDescription new
 		accessor: #name;
 		csvFieldName: 'Name';
+		priority: 10;
 		yourself
 ]
 
@@ -64,6 +106,17 @@ MACSVTestPerson >> phoneNumberDescription [
 	^ MANumberDescription new
 		accessor: #phoneNumber;
 		csvFieldName: 'Phone Number';
+		priority: 20;
 		csvReader: [ :s | (s select: #isDigit) asNumber ];
 		yourself
+]
+
+{ #category : #accessing }
+MACSVTestPerson >> wikipediaUrl [
+	^ wikipediaUrl
+]
+
+{ #category : #accessing }
+MACSVTestPerson >> wikipediaUrl: anObject [
+	wikipediaUrl := anObject
 ]

--- a/repository/Neo-CSV-Magritte/MACSVWriter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVWriter.class.st
@@ -1,0 +1,121 @@
+Class {
+	#name : #MACSVWriter,
+	#superclass : #Object,
+	#instVars : [
+		'writer',
+		'writerClass',
+		'target',
+		'subjects',
+		'map',
+		'subjectDescription'
+	],
+	#category : #'Neo-CSV-Magritte-Visitors'
+}
+
+{ #category : #accessing }
+MACSVWriter >> execute [
+	^ self target isStream
+		ifTrue: [ self writeToStream: self target ]
+		ifFalse: [ self target ensureCreateFile writeStreamDo: [ :str | self writeToStream: str ] ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> fieldNamePropertyKey [
+	"The property where the element description stores the field name; override to customize"
+
+	^ #csvFieldName
+]
+
+{ #category : #accessing }
+MACSVWriter >> fieldWriterPropertyKey [
+	"The property where the element description stores the field reader. Override to customize. See `MAElementDescription>>#csvReader:` method comment for more info"
+
+	^ #csvWriter
+]
+
+{ #category : #accessing }
+MACSVWriter >> map [
+
+	^ map ifNil: [ map := OrderedCollection new ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> map: aString fieldDo: aBlock [
+
+	| field |
+	field := MACSVField new
+		name: aString;
+		yourself.
+		
+	aBlock value: field.
+	
+	self map add: field.
+]
+
+{ #category : #private }
+MACSVWriter >> subjectDescription [
+	^ subjectDescription ifNil: [ subjectDescription := self subjects first magritteDescription ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> subjects [
+	^ subjects
+]
+
+{ #category : #accessing }
+MACSVWriter >> subjects: anObject [
+	subjects := anObject
+]
+
+{ #category : #accessing }
+MACSVWriter >> target [
+
+	^ target
+]
+
+{ #category : #accessing }
+MACSVWriter >> target: aFileOrStream [
+
+	target := aFileOrStream
+]
+
+{ #category : #private }
+MACSVWriter >> writeToStream: aStream [
+	| fieldDescriptions header |
+
+	self map do: [ :field | field configureDescriptionFor: self ].
+	
+	fieldDescriptions := self subjectDescription
+		select: [ :desc | desc hasProperty: self fieldNamePropertyKey ].
+
+	header := fieldDescriptions children
+			collect: [ :field | field propertyAt: self fieldNamePropertyKey ifAbsent: [ field name ] ].
+
+	fieldDescriptions
+		do: [ :field | 
+			| converter |
+			converter := field
+					propertyAt: self fieldWriterPropertyKey
+					ifAbsent: [ [ :anObject | field read: anObject ] ].
+			self writer addField: converter ].
+
+	self writer
+		on: aStream;
+		writeHeader: header;
+		nextPutAll: self subjects
+]
+
+{ #category : #accessing }
+MACSVWriter >> writer [
+	^ writer ifNil: [ writer := self writerClass new ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> writerClass [
+	^ writerClass ifNil: [ NeoCSVWriter ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> writerClass: aClass [
+	writerClass := aClass
+]

--- a/repository/Neo-CSV-Magritte/MACSVWriterTests.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVWriterTests.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : #MACSVWriterTests,
+	#superclass : #TestCase,
+	#instVars : [
+		'input',
+		'objects',
+		'person',
+		'target',
+		'writer'
+	],
+	#category : #'Neo-CSV-Magritte-Tests'
+}
+
+{ #category : #running }
+MACSVWriterTests >> setUp [
+	person :=  MACSVTestPerson exampleAlanKay.
+	target := FileSystem memory / 'people.csv'.
+	writer := MACSVWriter new
+		target: target;
+		subjects: { person };
+		yourself
+]
+
+{ #category : #tests }
+MACSVWriterTests >> testAddedDescription [
+
+	writer
+		map: 'Wikipedia' fieldDo: [ :field | 
+			field descriptionSource: [ 
+				MAUrlDescription new
+					accessor: #wikipediaUrl;
+					priority: 25;
+					csvFieldName: 'Wikipedia';
+					yourself ] ];
+		execute.
+		
+	self assert: target contents equals: '"Name","Phone Number","Wikipedia","DOB"
+"Alan Kay","","https://en.wikipedia.org/wiki/Alan_Kay","17 May 1940"
+' withUnixLineEndings.
+]
+
+{ #category : #tests }
+MACSVWriterTests >> testAlteredDescription [
+
+	writer
+		map: 'Birthplace String' fieldDo: [ :field | 
+			field descriptionSource: #birthplaceDescription ];
+		execute.
+		
+	self assert: target contents equals: '"Name","Phone Number","DOB","Birthplace String"
+"Alan Kay","","17 May 1940","Springfield, Massachusetts, U.S."
+' withUnixLineEndings.
+]
+
+{ #category : #tests }
+MACSVWriterTests >> testDefaultMapping [
+	writer execute.
+	self assert: target contents equals: '"Name","Phone Number","DOB"
+"Alan Kay","","17 May 1940"
+' withUnixLineEndings.
+]


### PR DESCRIPTION
- Analogous to the Magritte Importer, which should be renamed to Reader.
- New field definition class will allow CSV fields to be described once and used by readers and writers
- Includes tests