### PR TITLE
[Enh]: Reader Valuable - Second Optional Desc. Argument

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -86,7 +86,7 @@ MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionar
 					fieldReader := desc 
 						propertyAt: self fieldReaderPropertyKey
 						ifAbsent: [ desc csvReader ].
-					value := fieldReader value: stringValue.
+					value := fieldReader cull: stringValue cull: desc.
 					desc write: value to: anObject ] ] ].
 	^ anObject
 ]

--- a/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
+++ b/repository/Neo-CSV-Magritte/MAElementDescription.extension.st
@@ -19,7 +19,10 @@ MAElementDescription >> csvReader [
 { #category : #'*Neo-CSV-Magritte' }
 MAElementDescription >> csvReader: aBlock [
 	"
-	aBlock - should take the input string as its argument and return a value appropriate to the field e.g. aDate for MADateDescription."
+	aBlock 
+		- 1st argument - the input string
+		- 2nd (optional) argument - this description
+		- return value - a value appropriate to the field e.g. aDate for MADateDescription."
 	^ self propertyAt: #csvReader put: aBlock
 ]
 
@@ -33,7 +36,7 @@ MAElementDescription >> defaultCsvReader [
 MAElementDescription >> fromCSV: aStringOrNil [
 	| value |
 	(aStringOrNil isNil or: [ aStringOrNil isEmpty ]) ifTrue: [ ^ nil ].
-	value := self csvReader value: aStringOrNil trimmed.
+	value := self csvReader cull: aStringOrNil trimmed cull: self.
 	(self default = value and: [ self shouldCacheDefault not ]) ifTrue: [ ^ nil ].
 	^ value
 	"Implementation note: this was extracted from NeoCSVReader's Magritte field adding because it is useful in other places e.g. MACSVImporter"


### PR DESCRIPTION
Useful when building descriptions. For example, you could write something like:
```smalltalk
aDescription := MANumberDescription new
	csvReader: [ :input :desc | desc fromString: input trimmed ];
	yourself
```

... instead of:
```smalltalk
aDescription := MANumberDescription new.
aDescription csvReader: [ :input | aDescription fromString: input trimmed ].
^ aDescription
```