### PR TITLE
[Enh]: Magritte Writer - Sub. Desc. & Ignore Unknown Fields

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVWriter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVWriter.class.st
@@ -7,7 +7,8 @@ Class {
 		'target',
 		'subjects',
 		'map',
-		'subjectDescription'
+		'subjectDescription',
+		'ignoresUnkownFields'
 	],
 	#category : #'Neo-CSV-Magritte-Visitors'
 }
@@ -46,6 +47,16 @@ MACSVWriter >> header [
 ]
 
 { #category : #accessing }
+MACSVWriter >> ignoresUnknownFields [
+	^ ignoresUnkownFields ifNil: [ false ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> ignoresUnknownFields: anObject [
+	ignoresUnkownFields := anObject
+]
+
+{ #category : #accessing }
 MACSVWriter >> includesHeader [
 	^ includesHeader ifNil: [ true ].
 ]
@@ -74,9 +85,14 @@ MACSVWriter >> map: aString fieldDo: aBlock [
 	self map add: field.
 ]
 
-{ #category : #private }
+{ #category : #accessing }
 MACSVWriter >> subjectDescription [
 	^ subjectDescription ifNil: [ subjectDescription := self subjects first magritteDescription ]
+]
+
+{ #category : #accessing }
+MACSVWriter >> subjectDescription: anMAContainer [
+	subjectDescription := anMAContainer
 ]
 
 { #category : #accessing }
@@ -109,11 +125,15 @@ MACSVWriter >> writeToStream: aStream [
 
 	self fieldDescriptions
 		do: [ :field | 
-			| converter |
+			| converter wrappedConverter |
 			converter := field
 					propertyAt: self fieldWriterPropertyKey
 					ifAbsent: [ [ :anObject | field read: anObject ] ].
-			self writer addField: converter ].
+			wrappedConverter := [ :anObject |
+				(self ignoresUnknownFields not or: [ field accessor canRead: anObject ])
+					ifTrue: [ converter value: anObject ]
+					ifFalse: [ nil ] ].
+			self writer addField: wrappedConverter ].
 
 	writer := self writer on: aStream.
 

--- a/repository/Neo-CSV-Magritte/MACSVWriterTests.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVWriterTests.class.st
@@ -59,3 +59,55 @@ MACSVWriterTests >> testDefaultMapping [
 "Alan Kay","","17 May 1940"
 ' withUnixLineEndings.
 ]
+
+{ #category : #tests }
+MACSVWriterTests >> testIgnoreUnknownFields [
+
+	| field substitution unknownField |
+	field := MACSVTestPerson magritteTemplate birthdateDescription.
+	unknownField := MAStringDescription new
+		accessor: #unknownSelector;
+		csvFieldName: 'Unknown';
+		priority: 10;
+		yourself.
+	substitution := MAContainer withAll: { field. unknownField }.
+		
+	writer
+		subjectDescription: substitution;
+		ignoresUnknownFields: true;
+		execute.
+		
+	self assert: target contents equals: '"DOB","Unknown"
+"17 May 1940",""
+' withUnixLineEndings.
+]
+
+{ #category : #tests }
+MACSVWriterTests >> testSubjectDescriptionSubstitution [
+
+	writer
+		subjectDescription: MACSVTestPerson magritteTemplate birthdateDescription asContainer;
+		execute.
+		
+	self assert: target contents equals: '"DOB"
+"17 May 1940"
+' withUnixLineEndings.
+]
+
+{ #category : #tests }
+MACSVWriterTests >> testUnknownFields [
+
+	| unknownField |
+	unknownField := MAStringDescription new
+		accessor: #unknownSelector;
+		csvFieldName: 'Unknown';
+		priority: 10;
+		yourself.
+		
+	self 
+		should: [ 
+			writer
+				subjectDescription: unknownField asContainer;
+				execute ] 
+		raise: MessageNotUnderstood.
+]


### PR DESCRIPTION
- Specify a substitute description
- Option to skip unknown fields instead of signalling an error
- Tests for the above