### PR TITLE
Magritte Two Stage Importer - Enable Record Class

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -19,6 +19,7 @@ Class {
 MACSVTwoStageImporter >> configureReaderFor: aStream [
 	
 	super configureReaderFor: aStream.
+	self reader recordClass: Dictionary.
 	
 	self reader
 		emptyFieldValue: #passNil;

--- a/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVTwoStageImporter.class.st
@@ -88,7 +88,7 @@ MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionar
 { #category : #accessing }
 MACSVTwoStageImporter >> initializeDomainObject: anObject fromRecord: aDictionary mapping: mapBlock descriptionDo: descriptionBlock [
 	"
-	anObject - domain objec to be initialized
+	anObject - domain object to be initialized
 	aDictionary - keys are CSV column names
 	mapBlock - use to modify existing descriptions; argument will be an MACSVMappingPragmaBuilder to configure
 	descriptionBlock - argument is the container description for anObject, for further configuration e.g. adding an element description"


### PR DESCRIPTION
This is still a useful concept, as in the superclass, but we have to remember to set the record class back to Dictionary in the first pass/stage