### PR TITLE
[Enh]: Magritte CSV Writer - Support Non-SequencedCollections

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVWriter.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVWriter.class.st
@@ -96,7 +96,7 @@ MACSVWriter >> map: aString fieldSource: aBlock [
 
 { #category : #accessing }
 MACSVWriter >> subjectDescription [
-	^ subjectDescription ifNil: [ subjectDescription := self subjects first magritteDescription ]
+	^ subjectDescription ifNil: [ subjectDescription := self subjects atRandom magritteDescription ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Replace `first	`, which fails for e.g. Sets, with `atRandom`