### PR TITLE
Refactor group names in BaselineOfNeoCSV class

### DIFF
--- a/repository/BaselineOfNeoCSV/BaselineOfNeoCSV.class.st
+++ b/repository/BaselineOfNeoCSV/BaselineOfNeoCSV.class.st
@@ -17,8 +17,11 @@ BaselineOfNeoCSV >> baseline: spec [
 				package: 'Neo-CSV-Core';
 				package: 'Neo-CSV-Tests' with: [ spec requires: #('Neo-CSV-Core') ];
 				package: 'Neo-CSV-Magritte' with: [ spec requires: #('Neo-CSV-Core') ];
-				group: 'default' with: #('core' 'tests');
-				group: 'core' with: #('Neo-CSV-Core');
-				group: 'magritte' with: #('Neo-CSV-Magritte');
-				group: 'tests' with: #('Neo-CSV-Tests') ]
+				group: 'default' with: #('Core' 'Tests');
+				group: 'Core' with: #('Neo-CSV-Core');
+				group: 'core' with: #('Core');
+				group: 'Magritte' with: #('Neo-CSV-Magritte');
+				group: 'magritte' with: #('Magritte');
+				group: 'Tests' with: #('Neo-CSV-Tests');
+				group: 'tests' with: #('Tests') ]
 ]


### PR DESCRIPTION
Refactoring group names in favor of standard groups e.g. Core to start with capital letter as done in other repositories.

Other general names like e.g. default stay the same.

For compatibility reason adding aliases for the lower case  group variants to prevent any impact on the end user.