### PR TITLE
Fixing test to show what is actually being tested; not what just works

### DIFF
--- a/repository/Neo-CSV-Tests/NeoCSVReaderTests.class.st
+++ b/repository/Neo-CSV-Tests/NeoCSVReaderTests.class.st
@@ -107,27 +107,26 @@ NeoCSVReaderTests >> testEmptyConversionsTestObject [
 
 { #category : #testing }
 NeoCSVReaderTests >> testEmptyFieldInput [
-	self 
+	self
 		assert: ((NeoCSVReader on: 'one,NULL,two\NULL,NULL,three\NULL,NULL,NULL' withCRs readStream)
-						 emptyFieldInput: [ :field | field = 'NULL' ]; upToEnd)
-		equals: #((one nil two) (nil nil three) (nil nil nil)).
-	self 
+					emptyFieldInput: [ :field | field = 'NULL' ]; upToEnd)
+		equals: #(('one' nil 'two') (nil nil 'three') (nil nil nil)).
+	self
 		assert: ((NeoCSVReader on: 'one,NULL,two\NULL,NULL,three\NULL,NULL,NULL' withCRs readStream)
-						 emptyFieldInput: [ :field | field = 'NULL' ]; emptyFieldValue: #empty; upToEnd)
-		equals: #((one empty two) (empty empty three) (empty empty empty)).
-	self 
+					emptyFieldInput: [ :field | field = 'NULL' ]; emptyFieldValue: #empty; upToEnd)
+		equals: #(('one' empty 'two') (empty empty 'three') (empty empty empty)).
+	self
 		assert: ((NeoCSVReader on: 'one, NULL,two\" NULL","NULL ","three"\NULL,NULL,NULL' withCRs readStream)
-						 emptyFieldInput: [ :field | field trimBoth asLowercase = #null ]; emptyFieldValue: #empty; upToEnd)
-		equals: #((one empty two) (empty empty three) (empty empty empty)).
-	self 
+					emptyFieldInput: [ :field | field trimBoth asLowercase = 'null' ]; emptyFieldValue: #empty; upToEnd)
+		equals: #(('one' empty 'two') (empty empty 'three') (empty empty empty)).
+	self
 		assert: ((NeoCSVReader on: 'one,NULL,two\"nil","NULL","three"\nil,NULL,nil' withCRs readStream)
-						 emptyFieldInput: [ :field | #('NULL' 'nil') includes: field ]; emptyFieldValue: #empty; upToEnd)
-		equals: #((one empty two) (empty empty three) (empty empty empty)).
+					emptyFieldInput: [ :field | #('NULL' 'nil') includes: field ]; emptyFieldValue: #empty; upToEnd)
+		equals: #(('one' empty 'two') (empty empty 'three') (empty empty empty)).
 	self 
 		assert: ((NeoCSVReader on: 'one,,two\,,three\,,' withCRs readStream)
-						 emptyFieldInput: [ :field | field isEmpty ]; upToEnd)
-		equals: #((one nil two) (nil nil three) (nil nil nil)).
-
+					emptyFieldInput: [ :field | field isEmpty ]; upToEnd)
+		equals: #(('one' nil 'two') (nil nil 'three') (nil nil nil))
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Test relies on a fact that 'one' = #one. The reality is that the result is e.g 'one' and not #one. In GemStone 'one' ~= #one so we need to fix it properly.