### PR TITLE
Make date compatible everywhere and simple

### DIFF
--- a/repository/Neo-CSV-Magritte/MACSVImporterTests.class.st
+++ b/repository/Neo-CSV-Magritte/MACSVImporterTests.class.st
@@ -32,7 +32,7 @@ MACSVImporterTests >> testCustomConversion [
 MACSVImporterTests >> testDateDefaultConversion [
 	self readInput: 'DOB,Ignored Field
 2/28/2020,something'.
-	self assert: objects first birthdate equals: '2/28/2020' asDate.
+	self assert: objects first birthdate equals: (Date year: 2020 month: 2 day: 28).
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Testing is really done on the input and comparing it in a compatible way is removing the need for String to Date conversion.